### PR TITLE
修改自瞄模式控制目标值获取，改为通过指针读取，而不是直接在自瞄中使用函数返回

### DIFF
--- a/User/application/module/gimbal/auto_shoot.c
+++ b/User/application/module/gimbal/auto_shoot.c
@@ -328,26 +328,6 @@ void auto_shoot_solve_trajectory(solver_track_t *solver_track, send_packed_t *se
 }
 
 /**
-  * @brief          解算完成后由该函数设置云台电机的目标角度，用于后续的云台控制
-  * @author         RM
-  * @param[in]      yaw_target  : yaw轴角度控制，为角度的增量 单位 rad
-  * @param[in]      pitch_target: pitch轴角度控制，为角度的增量 单位 rad
-  * @retval         none
-  */
-void set_auto_shoot_target(fp32* yaw_target,fp32* pitch_target)
-{
-    if (yaw_target == NULL || pitch_target == NULL)
-    {
-        return;
-    }
-    if(auto_shoot.received_packed.tracking)  //识别到目标
-    {
-        *pitch_target = auto_shoot.solver_track.target_pitch;
-        *yaw_target   = rad_format(auto_shoot.solver_track.target_yaw);
-    }
-}
-
-/**
  * @brief  向上位机发送数据
  * @retval 无
  */

--- a/User/application/module/gimbal/auto_shoot.h
+++ b/User/application/module/gimbal/auto_shoot.h
@@ -167,8 +167,6 @@ void auto_shoot_solve_trajectory(solver_track_t *solver_track, send_packed_t *se
 void autoshoot_prepare_send_data(const received_packed_t *received_packed, send_packed_t *send_packed,
                                  solver_track_t *solver_track);
 
-void set_auto_shoot_target(fp32* yaw_target,fp32* pitch_target);   //设置云台自瞄目标值
-
 // 获取自瞄实例
 auto_shoot_t *auto_shoot_get_instance(void);
 

--- a/User/application/module/gimbal/gimbal.c
+++ b/User/application/module/gimbal/gimbal.c
@@ -61,6 +61,8 @@ void gimbal_init(gimbal_control_t* init)
 	init->gimbal_INT_angle_point = get_INS_angle_point();  // 获取惯性导航系统（INS）角度数据指针
 	init->gimbal_INT_gyro_point = get_gyro_data_point();   // 获取陀螺仪数据指针
 
+    init->auto_shoot_point = auto_shoot_get_instance();   //获取自瞄任务指针
+
 	// 获取遥控器数据指针
 	init->gimbal_rc_ctrl = get_dt7_point();  // 获取遥控器数据指针
 

--- a/User/application/module/gimbal/gimbal.h
+++ b/User/application/module/gimbal/gimbal.h
@@ -10,6 +10,7 @@
 #include "dt7.h"
 #include "pid.h"
 #include "imu.h"
+#include "auto_shoot.h"
 
 //pitch 速度环 PID参数以及 PID最大输出，积分输出
 #define PITCH_SPEED_PID_KP        2000.0f//1500
@@ -177,6 +178,7 @@ typedef struct
 typedef struct
 {
 	const RC_ctrl_t* gimbal_rc_ctrl;        // 指向云台遥控控制输入的常量指针。
+    const auto_shoot_t * auto_shoot_point;                   //
 	const fp32* gimbal_INT_angle_point;     // 指向内部角度传感器数据点的常量指针，单位弧度。
 	const fp32* gimbal_INT_gyro_point;      // 指向内部陀螺仪传感器数据点的常量指针，单位弧度每秒。
 	gimbal_motor_t gimbal_yaw_motor;        // 控制云台偏航电机的数据和控制变量的结构体。

--- a/User/application/module/gimbal/gimbal_behaviour.c
+++ b/User/application/module/gimbal/gimbal_behaviour.c
@@ -376,10 +376,16 @@ static void gimbal_auto_angle_control(fp32 *add_yaw, fp32 *add_pitch,__attribute
     //云台目标设置值临时变量
     fp32 yaw_target, pitch_target;
     //设置云台目标
-    set_auto_shoot_target(&yaw_target,&pitch_target);
+    if(gimbal_control_set->auto_shoot_point->received_packed.tracking)  //识别到目标
+    {
+        pitch_target = gimbal_control_set->auto_shoot_point->solver_track.target_pitch;
+        yaw_target   = rad_format(gimbal_control_set->auto_shoot_point->solver_track.target_yaw);
+    }
     //计算云台目标增量
     *add_yaw   = yaw_target   - gimbal_control_set->gimbal_yaw_motor.absolute_angle;
     *add_pitch = pitch_target - gimbal_control_set->gimbal_pitch_motor.absolute_angle;
+
+
 }
 
 /**

--- a/User/application/module/gimbal/gimbal_behaviour.h
+++ b/User/application/module/gimbal/gimbal_behaviour.h
@@ -11,6 +11,7 @@
 #include "gimbal.h"
 #include "feedforward.h"
 #include "auto_shoot.h"
+#include "user_lib.h"
 
 typedef enum
 {

--- a/User/components/algorithm/user_lib/user_lib.h
+++ b/User/components/algorithm/user_lib/user_lib.h
@@ -2,6 +2,10 @@
 #define USER_LIB_H
 #include "struct_typedef.h"
 
+#ifndef PI
+#define PI  3.1415926536f
+#endif
+
 typedef struct
 {
     fp32 input;        //输入数据


### PR DESCRIPTION
修改了自瞄模式下云台目标值获取方式，改成通过初始化指针对象后，直接读取指针指向空间的值，而不是每次使用时再通过函数返回去获取目标值